### PR TITLE
master-2.x changes since April 22, 2019

### DIFF
--- a/ApplicationLogs/ApplicationLogs.csproj
+++ b/ApplicationLogs/ApplicationLogs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.10.1</Version>
+    <Version>2.10.2</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Neo.Plugins</RootNamespace>
   </PropertyGroup>
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo" Version="2.10.1" />
+    <PackageReference Include="Neo" Version="2.10.2" />
   </ItemGroup>
 
 </Project>

--- a/ApplicationLogs/ApplicationLogs.csproj
+++ b/ApplicationLogs/ApplicationLogs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.10.2</Version>
+    <Version>2.10.3</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Neo.Plugins</RootNamespace>
   </PropertyGroup>
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo" Version="2.10.2" />
+    <PackageReference Include="Neo" Version="2.10.3" />
   </ItemGroup>
 
 </Project>

--- a/CoreMetrics/CoreMetrics.cs
+++ b/CoreMetrics/CoreMetrics.cs
@@ -71,10 +71,10 @@ namespace Neo.Plugins
             uint heightToBegin = lastHeight > 0 ? lastHeight - nBlocks : (Blockchain.Singleton.Height - 1) - nBlocks;
             for (uint i = heightToBegin; i <= heightToBegin + nBlocks; i++)
             {
-                JObject json = new JObject();
                 Header header = Blockchain.Singleton.Store.GetHeader(i);
                 if (header == null) break;
 
+                JObject json = new JObject();
                 json["timestamp"] = header.Timestamp;
                 json["height"] = i;
                 array.Add(json);

--- a/CoreMetrics/CoreMetrics.cs
+++ b/CoreMetrics/CoreMetrics.cs
@@ -8,13 +8,9 @@ namespace Neo.Plugins
 {
     public class CoreMetrics : Plugin, IRpcPlugin
     {
-        public override void Configure()
-        {
-        }
+        public override void Configure() { }
 
-        public void PreProcess(HttpContext context, string method, JArray _params)
-        {
-        }
+        public void PreProcess(HttpContext context, string method, JArray _params) { }
 
         public JObject OnProcess(HttpContext context, string method, JArray _params)
         {
@@ -32,9 +28,7 @@ namespace Neo.Plugins
             }
         }
 
-        public void PostProcess(HttpContext context, string method, JArray _params, JObject result)
-        {
-        }
+        public void PostProcess(HttpContext context, string method, JArray _params, JObject result) { }
 
         private JObject GetBlocksTime(uint nBlocks, uint lastHeight)
         {
@@ -79,6 +73,8 @@ namespace Neo.Plugins
             {
                 JObject json = new JObject();
                 Header header = Blockchain.Singleton.Store.GetHeader(i);
+                if (header == null) break;
+
                 json["timestamp"] = header.Timestamp;
                 json["height"] = i;
                 array.Add(json);

--- a/CoreMetrics/CoreMetrics.cs
+++ b/CoreMetrics/CoreMetrics.cs
@@ -64,7 +64,7 @@ namespace Neo.Plugins
             if (nBlocks >= Blockchain.Singleton.Height)
             {
                 JObject json = new JObject();
-                return json["error"] = "Requested number of blocks timestamps exceeds quantity of known blocks " + Blockchain.Singleton.Height;
+                return json["error"] = "Requested number of blocks timestamps " + nBlocks + " exceeds quantity of known blocks " + Blockchain.Singleton.Height;
             }
 
             if (nBlocks <= 0)
@@ -74,8 +74,8 @@ namespace Neo.Plugins
             }
 
             JArray array = new JArray();
-            uint heightToBegin = lastHeight > 0 ? lastHeight - nBlocks : Blockchain.Singleton.Height - nBlocks;
-            for (uint i = heightToBegin; i <= Blockchain.Singleton.HeaderHeight; i++)
+            uint heightToBegin = lastHeight > 0 ? lastHeight - nBlocks : (Blockchain.Singleton.Height - 1) - nBlocks;
+            for (uint i = heightToBegin; i <= heightToBegin + nBlocks; i++)
             {
                 JObject json = new JObject();
                 Header header = Blockchain.Singleton.Store.GetHeader(i);

--- a/CoreMetrics/CoreMetrics.csproj
+++ b/CoreMetrics/CoreMetrics.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.10.2</Version>
+    <Version>2.10.3</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Neo.Plugins</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo" Version="2.10.2" />
+    <PackageReference Include="Neo" Version="2.10.3" />
   </ItemGroup>
 
 </Project>

--- a/CoreMetrics/CoreMetrics.csproj
+++ b/CoreMetrics/CoreMetrics.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.10.1</Version>
+    <Version>2.10.2</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Neo.Plugins</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo" Version="2.10.1" />
+    <PackageReference Include="Neo" Version="2.10.2" />
   </ItemGroup>
 
 </Project>

--- a/ImportBlocks/ImportBlocks.cs
+++ b/ImportBlocks/ImportBlocks.cs
@@ -19,79 +19,77 @@ namespace Neo.Plugins
 
         private bool OnExport(string[] args)
         {
+            bool writeStart;
+            uint start, count;
+            string path;
             if (args.Length < 2) return false;
             if (!string.Equals(args[1], "block", StringComparison.OrdinalIgnoreCase)
                 && !string.Equals(args[1], "blocks", StringComparison.OrdinalIgnoreCase))
                 return false;
-            if (args.Length >= 3 && uint.TryParse(args[2], out uint start))
+            if (args.Length >= 3 && uint.TryParse(args[2], out start))
             {
-                if (start > Blockchain.Singleton.Height)
-                    return true;
-                uint count = args.Length >= 4 ? uint.Parse(args[3]) : uint.MaxValue;
+                if (Blockchain.Singleton.Height < start) return true;
+                count = args.Length >= 4 ? uint.Parse(args[3]) : uint.MaxValue;
                 count = Math.Min(count, Blockchain.Singleton.Height - start + 1);
-                uint end = start + count - 1;
-                string path = $"chain.{start}.acc";
-                using (FileStream fs = new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None))
+                path = $"chain.{start}.acc";
+                writeStart = true;
+            }
+            else
+            {
+                start = 0;
+                count = Blockchain.Singleton.Height - start + 1;
+                path = args.Length >= 3 ? args[2] : "chain.acc";
+                writeStart = false;
+            }
+
+            WriteBlocks(start, count, path, writeStart);
+
+            Console.WriteLine();
+            return true;
+        }
+
+        private void WriteBlocks(uint start, uint count, string path, bool writeStart)
+        {
+            uint end = start + count - 1;
+            using (FileStream fs = new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None, 4096, FileOptions.WriteThrough))
+            {
+                if (fs.Length > 0)
                 {
-                    if (fs.Length > 0)
+                    byte[] buffer = new byte[sizeof(uint)];
+                    if (writeStart)
                     {
                         fs.Seek(sizeof(uint), SeekOrigin.Begin);
-                        byte[] buffer = new byte[sizeof(uint)];
                         fs.Read(buffer, 0, buffer.Length);
                         start += BitConverter.ToUInt32(buffer, 0);
                         fs.Seek(sizeof(uint), SeekOrigin.Begin);
                     }
                     else
                     {
-                        fs.Write(BitConverter.GetBytes(start), 0, sizeof(uint));
-                    }
-                    if (start <= end)
-                        fs.Write(BitConverter.GetBytes(count), 0, sizeof(uint));
-                    fs.Seek(0, SeekOrigin.End);
-                    using (Snapshot snapshot = Blockchain.Singleton.GetSnapshot())
-                        for (uint i = start; i <= end; i++)
-                        {
-                            Block block = snapshot.GetBlock(i);
-                            byte[] array = block.ToArray();
-                            fs.Write(BitConverter.GetBytes(array.Length), 0, sizeof(int));
-                            fs.Write(array, 0, array.Length);
-                            Console.SetCursorPosition(0, Console.CursorTop);
-                            Console.Write($"[{i}/{end}]");
-                        }
-                }
-            }
-            else
-            {
-                start = 0;
-                uint end = Blockchain.Singleton.Height;
-                uint count = end - start + 1;
-                string path = args.Length >= 3 ? args[2] : "chain.acc";
-                using (FileStream fs = new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None))
-                {
-                    if (fs.Length > 0)
-                    {
-                        byte[] buffer = new byte[sizeof(uint)];
                         fs.Read(buffer, 0, buffer.Length);
                         start = BitConverter.ToUInt32(buffer, 0);
                         fs.Seek(0, SeekOrigin.Begin);
                     }
-                    if (start <= end)
-                        fs.Write(BitConverter.GetBytes(count), 0, sizeof(uint));
-                    fs.Seek(0, SeekOrigin.End);
-                    using (Snapshot snapshot = Blockchain.Singleton.GetSnapshot())
-                        for (uint i = start; i <= end; i++)
-                        {
-                            Block block = snapshot.GetBlock(i);
-                            byte[] array = block.ToArray();
-                            fs.Write(BitConverter.GetBytes(array.Length), 0, sizeof(int));
-                            fs.Write(array, 0, array.Length);
-                            Console.SetCursorPosition(0, Console.CursorTop);
-                            Console.Write($"[{i}/{end}]");
-                        }
+                }
+                else
+                {
+                    if (writeStart)
+                    {
+                        fs.Write(BitConverter.GetBytes(start), 0, sizeof(uint));
+                    }
+                }
+                if (start <= end)
+                    fs.Write(BitConverter.GetBytes(count), 0, sizeof(uint));
+                fs.Seek(0, SeekOrigin.End);
+                for (uint i = start; i <= end; i++)
+                {
+                    Block block = Blockchain.Singleton.Store.GetBlock(i);
+                    byte[] array = block.ToArray();
+                    fs.Write(BitConverter.GetBytes(array.Length), 0, sizeof(int));
+                    fs.Write(array, 0, array.Length);
+                    Console.SetCursorPosition(0, Console.CursorTop);
+                    Console.Write($"[{i}/{end}]");
                 }
             }
-            Console.WriteLine();
-            return true;
         }
 
         private bool OnHelp(string[] args)

--- a/ImportBlocks/ImportBlocks.csproj
+++ b/ImportBlocks/ImportBlocks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.10.1</Version>
+    <Version>2.10.2</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Neo.Plugins</RootNamespace>
   </PropertyGroup>
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo" Version="2.10.1" />
+    <PackageReference Include="Neo" Version="2.10.2" />
   </ItemGroup>
 
 </Project>

--- a/ImportBlocks/ImportBlocks.csproj
+++ b/ImportBlocks/ImportBlocks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.10.2</Version>
+    <Version>2.10.3</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Neo.Plugins</RootNamespace>
   </PropertyGroup>
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo" Version="2.10.2" />
+    <PackageReference Include="Neo" Version="2.10.3" />
   </ItemGroup>
 
 </Project>

--- a/RpcNep5Tracker/RpcNep5Tracker.cs
+++ b/RpcNep5Tracker/RpcNep5Tracker.cs
@@ -191,10 +191,12 @@ namespace Neo.Plugins
                     script = sb.ToArray();
                 }
 
-                ApplicationEngine engine = ApplicationEngine.Run(script, snapshot, extraGAS: new Fixed8(100000000));
-                if (engine.State.HasFlag(VMState.FAULT)) continue;
-                if (engine.ResultStack.Count <= 0) continue;
-                nep5BalancePair.Value.Balance = engine.ResultStack.Pop().GetBigInteger();
+                using (ApplicationEngine engine = ApplicationEngine.Run(script, snapshot, extraGAS: new Fixed8(100000000)))
+                {
+                    if (engine.State.HasFlag(VMState.FAULT)) continue;
+                    if (engine.ResultStack.Count <= 0) continue;
+                    nep5BalancePair.Value.Balance = engine.ResultStack.Pop().GetBigInteger();
+                }
                 nep5BalancePair.Value.LastUpdatedBlock = snapshot.Height;
                 if (nep5BalancePair.Value.Balance == 0)
                 {

--- a/RpcNep5Tracker/RpcNep5Tracker.cs
+++ b/RpcNep5Tracker/RpcNep5Tracker.cs
@@ -35,6 +35,7 @@ namespace Neo.Plugins
         private uint _maxResults;
         private bool _shouldTrackNonStandardMintTokensEvent;
         private Neo.IO.Data.LevelDB.Snapshot _levelDbSnapshot;
+        private static readonly Fixed8 maxGas = Fixed8.FromDecimal(1m);
 
         public override void Configure()
         {
@@ -191,12 +192,13 @@ namespace Neo.Plugins
                     script = sb.ToArray();
                 }
 
-                using (ApplicationEngine engine = ApplicationEngine.Run(script, snapshot, extraGAS: new Fixed8(100000000)))
+                using (ApplicationEngine engine = ApplicationEngine.Run(script, snapshot, extraGAS: maxGas))
                 {
                     if (engine.State.HasFlag(VMState.FAULT)) continue;
                     if (engine.ResultStack.Count <= 0) continue;
                     nep5BalancePair.Value.Balance = engine.ResultStack.Pop().GetBigInteger();
                 }
+
                 nep5BalancePair.Value.LastUpdatedBlock = snapshot.Height;
                 if (nep5BalancePair.Value.Balance == 0)
                 {

--- a/RpcNep5Tracker/RpcNep5Tracker.cs
+++ b/RpcNep5Tracker/RpcNep5Tracker.cs
@@ -191,7 +191,7 @@ namespace Neo.Plugins
                     script = sb.ToArray();
                 }
 
-                ApplicationEngine engine = ApplicationEngine.Run(script, snapshot, extraGAS: 100000000);
+                ApplicationEngine engine = ApplicationEngine.Run(script, snapshot, extraGAS: new Fixed8(100000000));
                 if (engine.State.HasFlag(VMState.FAULT)) continue;
                 if (engine.ResultStack.Count <= 0) continue;
                 nep5BalancePair.Value.Balance = engine.ResultStack.Pop().GetBigInteger();

--- a/RpcNep5Tracker/RpcNep5Tracker.cs
+++ b/RpcNep5Tracker/RpcNep5Tracker.cs
@@ -12,6 +12,7 @@ using Neo.VM;
 using Neo.Wallets;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Numerics;
 using System.Text;
@@ -40,7 +41,7 @@ namespace Neo.Plugins
             if (_db == null)
             {
                 var dbPath = GetConfiguration().GetSection("DBPath").Value ?? "Nep5BalanceData";
-                _db = DB.Open(dbPath, new Options { CreateIfMissing = true });
+                _db = DB.Open(Path.GetFullPath(dbPath), new Options { CreateIfMissing = true });
             }
             _shouldTrackHistory = (GetConfiguration().GetSection("TrackHistory").Value ?? true.ToString()) != false.ToString();
             _recordNullAddressHistory = (GetConfiguration().GetSection("RecordNullAddressHistory").Value ?? false.ToString()) != false.ToString();
@@ -67,10 +68,10 @@ namespace Neo.Plugins
         private void RecordTransferHistory(Snapshot snapshot, UInt160 scriptHash, UInt160 from, UInt160 to, BigInteger amount, UInt256 txHash, ref ushort transferIndex)
         {
             if (!_shouldTrackHistory) return;
+            Header header = snapshot.GetHeader(snapshot.Height);
             if (_recordNullAddressHistory || from != UInt160.Zero)
             {
-                _transfersSent.Add(new Nep5TransferKey(from,
-                        snapshot.GetHeader(snapshot.Height).Timestamp, scriptHash, transferIndex),
+                _transfersSent.Add(new Nep5TransferKey(from, header.Timestamp, scriptHash, transferIndex),
                     new Nep5Transfer
                     {
                         Amount = amount,
@@ -82,8 +83,7 @@ namespace Neo.Plugins
 
             if (_recordNullAddressHistory || to != UInt160.Zero)
             {
-                _transfersReceived.Add(new Nep5TransferKey(to,
-                        snapshot.GetHeader(snapshot.Height).Timestamp, scriptHash, transferIndex),
+                _transfersReceived.Add(new Nep5TransferKey(to, header.Timestamp, scriptHash, transferIndex),
                     new Nep5Transfer
                     {
                         Amount = amount,
@@ -191,7 +191,7 @@ namespace Neo.Plugins
                     script = sb.ToArray();
                 }
 
-                ApplicationEngine engine = ApplicationEngine.Run(script, snapshot);
+                ApplicationEngine engine = ApplicationEngine.Run(script, snapshot, extraGAS: 100000000);
                 if (engine.State.HasFlag(VMState.FAULT)) continue;
                 if (engine.ResultStack.Count <= 0) continue;
                 nep5BalancePair.Value.Balance = engine.ResultStack.Pop().GetBigInteger();

--- a/RpcNep5Tracker/RpcNep5Tracker.csproj
+++ b/RpcNep5Tracker/RpcNep5Tracker.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.10.2</Version>
+    <Version>2.10.3</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Neo.Plugins</RootNamespace>
     <LangVersion>latest</LangVersion>
@@ -12,6 +12,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Neo" Version="2.10.2" />
+    <PackageReference Include="Neo" Version="2.10.3" />
   </ItemGroup>
 </Project>

--- a/RpcNep5Tracker/RpcNep5Tracker.csproj
+++ b/RpcNep5Tracker/RpcNep5Tracker.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.10.1</Version>
+    <Version>2.10.2</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Neo.Plugins</RootNamespace>
     <LangVersion>latest</LangVersion>
@@ -12,6 +12,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Neo" Version="2.10.1" />
+    <PackageReference Include="Neo" Version="2.10.2" />
   </ItemGroup>
 </Project>

--- a/RpcSecurity/RpcSecurity.csproj
+++ b/RpcSecurity/RpcSecurity.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.10.1</Version>
+    <Version>2.10.2</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Neo.Plugins</RootNamespace>
   </PropertyGroup>
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo" Version="2.10.1" />
+    <PackageReference Include="Neo" Version="2.10.2" />
   </ItemGroup>
 
 </Project>

--- a/RpcSecurity/RpcSecurity.csproj
+++ b/RpcSecurity/RpcSecurity.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.10.2</Version>
+    <Version>2.10.3</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Neo.Plugins</RootNamespace>
   </PropertyGroup>
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo" Version="2.10.2" />
+    <PackageReference Include="Neo" Version="2.10.3" />
   </ItemGroup>
 
 </Project>

--- a/RpcSystemAssetTracker/RpcSystemAssetTracker.csproj
+++ b/RpcSystemAssetTracker/RpcSystemAssetTracker.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.10.1</Version>
+    <Version>2.10.2</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>Neo.Plugins</RootNamespace>
     <LangVersion>latest</LangVersion>
@@ -12,6 +12,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Neo" Version="2.10.1" />
+    <PackageReference Include="Neo" Version="2.10.2" />
   </ItemGroup>
 </Project>

--- a/RpcSystemAssetTracker/RpcSystemAssetTracker.csproj
+++ b/RpcSystemAssetTracker/RpcSystemAssetTracker.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.10.2</Version>
+    <Version>2.10.3</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>Neo.Plugins</RootNamespace>
     <LangVersion>latest</LangVersion>
@@ -12,6 +12,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Neo" Version="2.10.2" />
+    <PackageReference Include="Neo" Version="2.10.3" />
   </ItemGroup>
 </Project>

--- a/RpcSystemAssetTracker/RpcSystemAssetTrackerPlugin.cs
+++ b/RpcSystemAssetTracker/RpcSystemAssetTrackerPlugin.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using Neo.Ledger;
 using Neo.Persistence;
 using Snapshot = Neo.Persistence.Snapshot;
+using System.IO;
 
 namespace Neo.Plugins
 {
@@ -33,7 +34,7 @@ namespace Neo.Plugins
             if (_db == null)
             {
                 var dbPath = GetConfiguration().GetSection("DBPath").Value ?? "SystemAssetBalanceData";
-                _db = DB.Open(dbPath, new Options { CreateIfMissing = true });
+                _db = DB.Open(Path.GetFullPath(dbPath), new Options { CreateIfMissing = true });
                 _shouldTrackUnclaimed = (GetConfiguration().GetSection("TrackUnclaimed").Value ?? true.ToString()) != false.ToString();
                 try
                 {

--- a/RpcWallet/RpcWallet.csproj
+++ b/RpcWallet/RpcWallet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.10.1</Version>
+    <Version>2.10.2</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Neo.Plugins</RootNamespace>
   </PropertyGroup>
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo" Version="2.10.1" />
+    <PackageReference Include="Neo" Version="2.10.2" />
   </ItemGroup>
 
 </Project>

--- a/RpcWallet/RpcWallet.csproj
+++ b/RpcWallet/RpcWallet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.10.2</Version>
+    <Version>2.10.3</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Neo.Plugins</RootNamespace>
   </PropertyGroup>
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo" Version="2.10.2" />
+    <PackageReference Include="Neo" Version="2.10.3" />
   </ItemGroup>
 
 </Project>

--- a/SimplePolicy.UnitTests/UT_SimplePolicy.cs
+++ b/SimplePolicy.UnitTests/UT_SimplePolicy.cs
@@ -18,7 +18,7 @@ namespace SimplePolicy.UnitTests
     [TestClass]
     public class UT_SimplePolicy
     {
-        private static Random _random = new Random(11121990);
+        private static readonly Random _random = new Random(11121990);
 
         SimplePolicyPlugin uut;
 
@@ -34,7 +34,6 @@ namespace SimplePolicy.UnitTests
             Settings.Default.MaxTransactionsPerBlock.Should().Be(500);
             Settings.Default.MaxFreeTransactionsPerBlock.Should().Be(20);
         }
-
 
         [TestMethod]
         public void TestFilterForBlock_ClaimHasPriority()
@@ -90,7 +89,7 @@ namespace SimplePolicy.UnitTests
             }
 
             TxList.Count().Should().Be(204); // 100 free + 100 paid + 4 claims
-            TxList.Where(tx => tx.NetworkFee == Fixed8.Zero).Count().Should().Be(100-18+4); // 82 fully free + 4 claims
+            TxList.Where(tx => tx.NetworkFee == Fixed8.Zero).Count().Should().Be(100 - 18 + 4); // 82 fully free + 4 claims
 
             IEnumerable<Transaction> filteredTxList = uut.FilterForBlock(TxList);
             //filteredTxList.Count().Should().Be(124); // 20 free + 100 paid + 4 claims
@@ -120,7 +119,7 @@ namespace SimplePolicy.UnitTests
             }
 
             TxList.Count().Should().Be(1004); // 500 free + 500 paid + 4 claims
-            TxList.Where(tx => tx.NetworkFee == Fixed8.Zero).Count().Should().Be(400+100-18+4); // 500-18 fully free + 4 claims
+            TxList.Where(tx => tx.NetworkFee == Fixed8.Zero).Count().Should().Be(400 + 100 - 18 + 4); // 500-18 fully free + 4 claims
 
             filteredTxList = uut.FilterForBlock(TxList);
             filteredTxList.Count().Should().Be(499); // full block
@@ -147,9 +146,7 @@ namespace SimplePolicy.UnitTests
             //Console.WriteLine("filtered");
             //foreach(var tx in filteredTxList)
             //    Console.WriteLine($"TX fee: {tx.NetworkFee} size: {tx.Size} ratio: {tx.FeePerByte} hash: {tx.Hash}" );
-
         }
-
 
         [TestMethod]
         public void FreeTxVerifySort_NoHighPriority()
@@ -244,7 +241,6 @@ namespace SimplePolicy.UnitTests
             txList.Where(tx => (tx.NetworkFee / tx.Size) == new Fixed8(2000) && (tx.NetworkFee > new Fixed8(20000))).Count().Should().Be(2); // only 2 survive (fee > 0.0002)
         }
 
-
         [TestMethod]
         public void FreeTxVerifySortWithPriority()
         {
@@ -273,7 +269,6 @@ namespace SimplePolicy.UnitTests
             filteredTxList.Where(tx => tx.Type == TransactionType.ClaimTransaction).Count().Should().Be(2); // 2 claims will be selected
         }
 
-
         [TestMethod]
         public void TestMock_GenerateInvocationTransaction()
         {
@@ -290,51 +285,48 @@ namespace SimplePolicy.UnitTests
             txLowPriority.Object.IsLowPriority.Should().Be(true);
         }
 
-         [TestMethod]
+        [TestMethod]
         public void TestVerifySizeLimits_FreeLessEq1024()
         {
             var txLowPriority = MockGenerateInvocationTransaction(new Fixed8(100000000 / 10000), 1024).Object; // 0.00001
             txLowPriority.IsLowPriority.Should().Be(true);
-            txLowPriority.Size.Should().Be(1024); 
+            txLowPriority.Size.Should().Be(1024);
             Settings.Default.MaxFreeTransactionSize.Should().Be(1024);
-            
+
             uut.VerifySizeLimits(txLowPriority).Should().Be(true); // 1024 <= 1024
         }
-
 
         [TestMethod]
         public void TestVerifySizeLimits_FreeGreater1024()
         {
             var txLowPriority = MockGenerateInvocationTransaction(new Fixed8(100000000 / 10000), 1025).Object; // 0.00001
             txLowPriority.IsLowPriority.Should().Be(true);
-            txLowPriority.Size.Should().Be(1025); 
+            txLowPriority.Size.Should().Be(1025);
             Settings.Default.MaxFreeTransactionSize.Should().Be(1024);
-            
+
             uut.VerifySizeLimits(txLowPriority).Should().Be(false); // 1025 > 1024
         }
-
 
         [TestMethod]
         public void TestVerifySizeLimits_HighPriorityLessEq1024()
         {
             var txHighPriority = MockGenerateInvocationTransaction(new Fixed8(100000000 / 1000), 1024).Object; // 0.0001
             txHighPriority.IsLowPriority.Should().Be(false);
-            txHighPriority.Size.Should().Be(1024); 
+            txHighPriority.Size.Should().Be(1024);
             Settings.Default.MaxFreeTransactionSize.Should().Be(1024);
-            
+
             uut.VerifySizeLimits(txHighPriority).Should().Be(true); // 1024 <= 1024
         }
-
 
         [TestMethod]
         public void TestVerifySizeLimits_HighPriorityGreater1024_1025()
         {
             var txHighPriority = MockGenerateInvocationTransaction(new Fixed8(100000000 / 1000), 1025).Object; // 0.0001
             txHighPriority.IsLowPriority.Should().Be(false);
-            txHighPriority.Size.Should().Be(1025); 
+            txHighPriority.Size.Should().Be(1025);
             Settings.Default.MaxFreeTransactionSize.Should().Be(1024);
             Settings.Default.FeePerExtraByte.Should().Be(new Fixed8(100000000 / 100000)); // 0.000001 (1000 satoshi)
-            
+
             uut.VerifySizeLimits(txHighPriority).Should().Be(true); // 1025 > 1024 (extra fee was 1 byte * 1000 satoshi = 0.000001)
         }
 
@@ -343,31 +335,31 @@ namespace SimplePolicy.UnitTests
         {
             var txHighPriority = MockGenerateInvocationTransaction(new Fixed8(100000000 / 1000), 1124).Object; // 0.0001
             txHighPriority.IsLowPriority.Should().Be(false);
-            txHighPriority.Size.Should().Be(1124); 
+            txHighPriority.Size.Should().Be(1124);
             Settings.Default.MaxFreeTransactionSize.Should().Be(1024);
             Settings.Default.FeePerExtraByte.Should().Be(new Fixed8(100000000 / 100000)); // 0.000001 (1000 satoshi)
-            
+
             uut.VerifySizeLimits(txHighPriority).Should().Be(true); // 1124 > 1024 (extra fee was 100 byte * 1000 satoshi = 0.0001)
         }
 
-         [TestMethod]
+        [TestMethod]
         public void TestVerifySizeLimits_HighPriorityGreater1024_1125_unpaid_fails()
         {
             var txHighPriority = MockGenerateInvocationTransaction(new Fixed8(100000000 / 1000), 1125).Object; // 0.0001
             txHighPriority.IsLowPriority.Should().Be(false);
-            txHighPriority.Size.Should().Be(1125); 
+            txHighPriority.Size.Should().Be(1125);
             Settings.Default.MaxFreeTransactionSize.Should().Be(1024);
             Settings.Default.FeePerExtraByte.Should().Be(new Fixed8(100000000 / 100000)); // 0.000001 (1000 satoshi)
             // should fail because of 1000 unpaid satoshi... (1 byte over)
             uut.VerifySizeLimits(txHighPriority).Should().Be(false); // 1125 > 1024 (extra fee was 101 byte * 1000 satoshi = 0.0001001)
         }
 
-                 [TestMethod]
+        [TestMethod]
         public void TestVerifySizeLimits_HighPriorityGreater1024_1125_paid_NotFail()
         {
             var txHighPriority = MockGenerateInvocationTransaction(new Fixed8(100000000 / 1000 + 1000), 1125).Object; // 0.000101
             txHighPriority.IsLowPriority.Should().Be(false);
-            txHighPriority.Size.Should().Be(1125); 
+            txHighPriority.Size.Should().Be(1125);
             Settings.Default.MaxFreeTransactionSize.Should().Be(1024);
             Settings.Default.FeePerExtraByte.Should().Be(new Fixed8(100000000 / 100000)); // 0.000001 (1000 satoshi)
             // should pass (total charged is 0.000101)
@@ -398,7 +390,6 @@ namespace SimplePolicy.UnitTests
             return mockTx;
         }
 
-
         // Create ClaimTransaction with 'countRefs' CoinReferences
         public static ClaimTransaction GetClaimTransaction(int countRefs)
         {
@@ -416,7 +407,7 @@ namespace SimplePolicy.UnitTests
             return new ClaimTransaction
             {
                 Claims = refs,
-                Attributes = new TransactionAttribute[]{new TransactionAttribute{Usage = TransactionAttributeUsage.Script, Data = randomBytes} },
+                Attributes = new TransactionAttribute[] { new TransactionAttribute { Usage = TransactionAttributeUsage.Script, Data = randomBytes } },
                 Inputs = new CoinReference[0],
                 Outputs = new TransactionOutput[0],
                 Witnesses = new Witness[0]

--- a/SimplePolicy/SimplePolicy.csproj
+++ b/SimplePolicy/SimplePolicy.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.10.1</Version>
+    <Version>2.10.2</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Neo.Plugins</RootNamespace>
     <LangVersion>latest</LangVersion>
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo" Version="2.10.1" />
+    <PackageReference Include="Neo" Version="2.10.2" />
   </ItemGroup>
 
 </Project>

--- a/SimplePolicy/SimplePolicy.csproj
+++ b/SimplePolicy/SimplePolicy.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.10.2</Version>
+    <Version>2.10.3</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Neo.Plugins</RootNamespace>
     <LangVersion>latest</LangVersion>
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo" Version="2.10.2" />
+    <PackageReference Include="Neo" Version="2.10.3" />
   </ItemGroup>
 
 </Project>

--- a/SimplePolicy/SimplePolicyPlugin.cs
+++ b/SimplePolicy/SimplePolicyPlugin.cs
@@ -96,7 +96,7 @@ namespace Neo.Plugins
             }
         }
 
-        private bool VerifySizeLimits(Transaction tx)
+        internal protected bool VerifySizeLimits(Transaction tx)
         {
             if (InHigherLowPriorityList(tx)) return true;
 

--- a/StatesDumper/Settings.cs
+++ b/StatesDumper/Settings.cs
@@ -16,7 +16,7 @@ namespace Neo.Plugins
         /// <summary>
         /// Height to begin real-time syncing and dumping on, consequently, dumping every block into a single files
         /// </summary>
-        public uint HeightToStartRealTimeSyncing { get; }
+        public int HeightToStartRealTimeSyncing { get; }
         /// <summary>
         /// Persisting actions
         /// </summary>
@@ -29,7 +29,7 @@ namespace Neo.Plugins
             /// Geting settings for storage changes state dumper
             this.BlockCacheSize = GetValueOrDefault(section.GetSection("BlockCacheSize"), 1000u, p => uint.Parse(p));
             this.HeightToBegin = GetValueOrDefault(section.GetSection("HeightToBegin"), 0u, p => uint.Parse(p));
-            this.HeightToStartRealTimeSyncing = GetValueOrDefault(section.GetSection("HeightToStartRealTimeSyncing"), 2883000u, p => uint.Parse(p));
+            this.HeightToStartRealTimeSyncing = GetValueOrDefault(section.GetSection("HeightToStartRealTimeSyncing"), -1, p => int.Parse(p));
             this.PersistAction = GetValueOrDefault(section.GetSection("PersistAction"), PersistActions.StorageChanges, p => (PersistActions)Enum.Parse(typeof(PersistActions), p));
         }
 

--- a/StatesDumper/StatesDumper.cs
+++ b/StatesDumper/StatesDumper.cs
@@ -131,7 +131,7 @@ namespace Neo.Plugins
             uint blockIndex = snapshot.Height;
             if (bs_cache.Count > 0)
             {
-                if ((blockIndex % Settings.Default.BlockCacheSize == 0) || (blockIndex > Settings.Default.HeightToStartRealTimeSyncing))
+                if ((blockIndex % Settings.Default.BlockCacheSize == 0) || (Settings.Default.HeightToStartRealTimeSyncing != -1 && blockIndex >= Settings.Default.HeightToStartRealTimeSyncing))
                 {
                     string dirPath = "./Storage";
                     Directory.CreateDirectory(dirPath);

--- a/StatesDumper/StatesDumper.csproj
+++ b/StatesDumper/StatesDumper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.10.1</Version>
+    <Version>2.10.2</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Neo.Plugins</RootNamespace>
   </PropertyGroup>
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo" Version="2.10.1" />
+    <PackageReference Include="Neo" Version="2.10.2" />
   </ItemGroup>
 
 </Project>

--- a/StatesDumper/StatesDumper.csproj
+++ b/StatesDumper/StatesDumper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.10.2</Version>
+    <Version>2.10.3</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Neo.Plugins</RootNamespace>
   </PropertyGroup>
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo" Version="2.10.2" />
+    <PackageReference Include="Neo" Version="2.10.3" />
   </ItemGroup>
 
 </Project>

--- a/StatesDumper/StatesDumper/config.json
+++ b/StatesDumper/StatesDumper/config.json
@@ -3,6 +3,6 @@
     "PersistAction": "StorageChanges",
     "BlockCacheSize": 1000,
     "HeightToBegin": 0,
-    "HeightToRealTimeSyncing": 2883000
+    "HeightToStartRealTimeSyncing": -1
   }
 }


### PR DESCRIPTION
This is a PR just to show the diff in the neo-project/neo-modules repo between commit `dc45d33` and the current master-2.x. This gives us an easy look at what has changed in the modules repo since April 22, 2019 to see what updates to current Neo2 we may have missed since then. The commit `dc45d33` just based on a date. We likely didn't base much of our node off of the code in neo-modules but we should check anyway. The commit to checkout and compare to was generally based just on where we are comparing the Neo repo from, which is around early March. See the Neo diff PR.